### PR TITLE
allow configuring editor availability from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ option(MOONCHILD_INPUT_SDL3 "Use SDL3 input backend" ON)
 
 option(MOONCHILD_AUDIO_SDL3 "Use SDL3 audio backend" ON)
 
+# Enable Editor
+option(MOONCHILD_ENABLE_EDITOR "Enable the level editor" OFF)
+if(MOONCHILD_ENABLE_EDITOR)
+  add_compile_definitions(EDITOR=1)
+endif()
+
 # Vendoring options
 option(MOONCHILD_VENDORED_SDL3 "Use vendored SDL3 library" ON)
 option(MOONCHILD_VENDORED_ZLIB "Use vendored zlib library" ON)

--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -41,11 +41,6 @@ int	  FirstTimeShowCredzFlg;
 #define DISCARD_UNUSED_PATS
 
 
-// if defined the editor is ready to go
-
-//#define EDITOR
-
-
 // if defined you're able to grab screenshots from movies and game!
 
 //#define GRABBER


### PR DESCRIPTION
No more editing source files randomly, just set a CMake option!

Seems pretty straightforward, this doesn't have to change the code since it just sets a compiler definition. May want to do this for a few of the other options in `mc.cpp`, but I mainly just wanted the editor to work this way.