### PR TITLE
Add speedrun mode

### DIFF
--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -298,15 +298,21 @@ void menuf1232(void);
 void menuf1233(void);
 void menuf1234(void);
 void menuf124(void);
+void menuf125(void);
+void menuf126(void);
 void menuf13(void);
 void menuf131(void);
 void menuf132(void);
+void menuf133(void);
+void menuf134(void);
 void menuf14(void);
 
 void letterswirlscan();
 void letterswirlin();
 void swirladd(char lett, UINT16 swirlx, UINT16 swirly);
 void letterswirlreset();
+
+void reset_game_progress(void);
 
 
 int MC_FLG;
@@ -355,6 +361,7 @@ UINT16    timerid;   // current ID of timer waiting for CD to finish
 
 UINT16    popupmenu;    // force popupmenu after spacebar in title menu
 UINT16    ingameflg;    // ingame flg   is 1 when we are IN the game and not in the title sequence
+SPEEDRUN_STATE speedrun_state;
 UINT16    levelloadedflg = 0;   // if 0 no level is loaded!
 UINT16    puzzleactiveflg = 0;  //if 1 puzzle is on screen
 #ifndef DEMOVERSION
@@ -558,12 +565,17 @@ MENU_ITEM menu1[] =
   { 0,0,0}
 };
 
+char *speedrun_toggle_on  = "+  SPEEDRUN : ON    ";
+char *speedrun_toggle_off = "   SPEEDRUN : OFF   ";
+
 MENU_ITEM menu12[] =
 {
-  {  5, menuf121, "        KEYS        "},
-  {  7, menuf122, "+      VIDEO        "},
-  {  9, menuf123, "+      AUDIO        "},
-  { 11, menuf124, "=      RETURN       "},
+  {  3, menuf121, "        KEYS        "},
+  {  5, menuf122, "+      VIDEO        "},
+  {  7, menuf123, "+      AUDIO        "},
+  {  9, menuf125, speedrun_toggle_off},
+  { 11, menuf126, "   RESET PROGRESS   "},
+  { 13, menuf124, "=      RETURN       "},
   { 0,0,0}
 };
 
@@ -646,6 +658,13 @@ MENU_ITEM menu13[] =
 {
   {  6, menuf131, "+LEAVE YOUR FRIEND  "},
   {  8, menuf132, "=      CANCEL       "},
+  { 0,0,0}
+};
+
+MENU_ITEM menu_confirmreset[] =
+{
+  {  6, menuf133, "   RESET PROGRESS   "},
+  {  8, menuf134, "       CANCEL       "},
   { 0,0,0}
 };
 
@@ -1814,6 +1833,7 @@ HEARTBEAT_FN MC_heartbeatstart(void)
   video->palette(gamepal);
 
   curlevel = world*4+level;
+  speedrun_state.leveltime[curlevel] = 0;
 
 //  abortblackdiamonds = blacksperlevel[curlevel];
 //  scoreabortblackdiamonds = scoreblacksperlevel[curlevel];
@@ -2596,6 +2616,12 @@ if(hoi!=NULL)
   }
 
 #endif
+
+  if (mc_autorun == 0)
+  {
+    speedrun_state.gametime += 1;
+    speedrun_state.leveltime[world*4+level] += 1;
+  }
 
 
 // if pause is active we stop here
@@ -7058,7 +7084,7 @@ HEARTBEAT_FN MC_menu(void)
       titlepic->draw_nokey(*refreshpic, 0, 0, 0, 0, 640, 480);
       menuleavefunc = (HEARTBEAT_FN) MC_leavemenu;
 	}
-    if (menupoint == menu12 || menupoint == menu13)
+    if (menupoint == menu12 || menupoint == menu13 || menupoint == menu_confirmreset)
 	{
       menupoint = menu1;
       menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
@@ -7243,6 +7269,16 @@ void menuf11(void)
   fadeout = 31;
   menuleavefunc = (HEARTBEAT_FN) MC_fadeout;
 };
+
+void reset_game_progress(void)
+{
+  
+  for (int i = 0; i < 13; i++)
+  {
+    maxlevel = 0;
+    blacksperlevel[i] = 0;
+  }
+}
 
 void menuf12(void)
 {
@@ -7491,6 +7527,40 @@ void menuf1234(void)
   menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
 };
 
+void menuf125(void)
+{
+  speedrun_state.running = !speedrun_state.running;
+  menu12[3].menutext = speedrun_state.running
+      ? speedrun_toggle_on
+      : speedrun_toggle_off;
+
+  start_afterbuilditem = menuitem;
+  menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
+}
+
+// Open progress reset confirmation submenu
+void menuf126(void)
+{
+  menupoint = menu_confirmreset;
+  menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
+}
+
+// Finalize progress reset
+void menuf133(void)
+{
+  menupoint = menu1;
+  reset_game_progress();
+  start_afterbuilditem = 0;
+  menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
+}
+
+// Cancel progress reset
+void menuf134(void)
+{
+  menupoint = menu12;
+  menuleavefunc = (HEARTBEAT_FN) MC_buildmenu;
+}
+
 void menuf124(void)
 {
   menupoint = menu1;
@@ -7599,6 +7669,11 @@ HEARTBEAT_FN MC_endsequence(void)
   puzzleinteractive = 1;      // if not first level become interactive (choose puzzlepiece!)
 
   ingameflg = 1;              // from this point onward we are IN the game
+  speedrun_state.gametime = 0;
+  for (int i = 0; i < 16; i++)
+  {
+    speedrun_state.leveltime[i] = 0;
+  }
 
 	LOG("G\n");
   configure_level(world+1,level+1);
@@ -7623,7 +7698,7 @@ HEARTBEAT_FN MC_buildmenu(void)
 
   if (menupoint != enter_menu)  // niet echt geweledig mooi... magoed, deadlines enzo..
     {
-      titlepic->draw_nokey(*refreshpic, 0, 160, 0, 160, 640, 480);
+      titlepic->draw_nokey(*refreshpic, 0, 0, 0, 0, 640, 480);
     }
 
   itemcnt = 0;

--- a/Classes/moonchild/mc.hpp
+++ b/Classes/moonchild/mc.hpp
@@ -60,6 +60,14 @@ struct LEVEL_DESCR
   TRIGGER_ITEM  *triglist;       // list with trigger descriptions for level
 };
 
+struct SPEEDRUN_STATE
+{
+  UINT32 gametime;
+  UINT32 leveltime[16];
+  bool running;
+};
+extern SPEEDRUN_STATE speedrun_state;
+
 
 void framework_ExitGame(void);
 HEARTBEAT_FN MC_heartbeat(void);

--- a/Classes/moonchild/score.cpp
+++ b/Classes/moonchild/score.cpp
@@ -8,6 +8,210 @@
 #include <boss.hpp>
 #include <sound.hpp>
 
+// 7x9
+static const char* smallfont[] =
+{
+  "  ...  "
+  " .   . "
+  " .   . "
+  " .   . "
+  " .   . "
+  " .   . "
+  " .   . "
+  " .   . "
+  "  ...  "
+  ,
+  "   .   "
+  "  ..   "
+  " . .   "
+  "   .   "
+  "   .   "
+  "   .   "
+  "   .   "
+  "   .   "
+  " ..... "
+  ,
+  "  ...  "
+  " .   . "
+  " .   . "
+  "     . "
+  "    .  "
+  "   .   "
+  "  .    "
+  " .     "
+  " ..... "
+  ,
+  "  ...  "
+  " .   . "
+  " .   . "
+  "     . "
+  "  ...  "
+  "     . "
+  " .   . "
+  " .   . "
+  "  ...  "
+  ,
+  "    . "
+  "    .. "
+  "   . . "
+  "  .  . "
+  " .   . "
+  " ..... "
+  "     . "
+  "     . "
+  "     . "
+  ,
+  " ..... "
+  " .     "
+  " .     "
+  " .     "
+  " ....  "
+  "     . "
+  "     . "
+  " .   . "
+  "  ...  "
+  ,
+  "  ...  "
+  " .     "
+  " .     "
+  " .     "
+  " ....  "
+  " .   . "
+  " .   . "
+  " .   . "
+  "  ...  "
+  ,
+  " ..... "
+  "     . "
+  "     . "
+  "    .  "
+  "    .  "
+  "    .  "
+  "   .   "
+  "   .   "
+  "   .   "
+  ,
+  "  ...  "
+  " .   . "
+  " .   . "
+  " .   . "
+  "  ...  "
+  " .   . "
+  " .   . "
+  " .   . "
+  "  ...  "
+  ,
+  "  ...  "
+  " .   . "
+  " .   . "
+  " .   . "
+  "  .... "
+  "     . "
+  "     . "
+  "     . "
+  "  ...  "
+  ,
+  "       "
+  "       "
+  "       "
+  "  .    "
+  "       "
+  "       "
+  "  .    "
+  "       "
+  "       "
+  ,
+  "       "
+  "       "
+  "       "
+  "       "
+  "       "
+  "       "
+  "       "
+  "       "
+  "  .    "
+};
+static const char* smallfontmap = "0123456789:.";
+
+static void drawsmallglyph(Cblitbuf& blitbuf, char glyph, BYTE color, UINT16 x, UINT16 y)
+{
+  UINT16 i;
+  const char* glyphptr = nullptr;
+  UINT16 xcnt;
+  UINT16 ycnt;
+
+  for (i=0;i<strlen(smallfontmap);i++)
+  {
+    if (smallfontmap[i] == glyph)
+    {
+      glyphptr = smallfont[i];
+      break;
+    }
+  }
+  if (glyphptr == nullptr) return;
+
+  xcnt = 0;
+  ycnt = 0;
+
+  BYTE* buf = blitbuf.lock_buffer();
+  UINT16 pitch = blitbuf.get_pitch();
+  while (*glyphptr)
+  {
+    if (*glyphptr == ' ')
+    {
+      xcnt++;
+    }
+    else
+    {
+      buf[((y+ycnt)*pitch) + ((x+xcnt)*1) + 0] = color;
+
+      xcnt++;
+    }
+
+    if (xcnt == 7)
+    {
+      xcnt = 0;
+      ycnt++;
+    }
+
+    glyphptr++;
+  }
+  blitbuf.unlock_buffer();
+}
+
+static void drawsmallfontstring(Cblitbuf& blitbuf, const char* str, BYTE color, UINT16 x, UINT16 y)
+{
+  UINT16 xcnt = x;
+
+  for (int i = 0; i < strlen(str); i++)
+  {
+    drawsmallglyph(blitbuf, str[i], color, xcnt, y);
+    xcnt += 8;
+  }
+}
+
+static void drawshadowsmallfontstring(Cblitbuf& blitbuf, const char* str, BYTE color, UINT16 x, UINT16 y)
+{
+  drawsmallfontstring(blitbuf, str, 0, x+1, y);
+  drawsmallfontstring(blitbuf, str, 0, x, y+1);
+  drawsmallfontstring(blitbuf, str, 0, x+1, y+1);
+  drawsmallfontstring(blitbuf, str, color, x, y);
+}
+
+static void drawgametime(UINT32 ticks, Cblitbuf& blitbuf, BYTE color, UINT16 x, UINT16 y)
+{
+  UINT32 centiseconds = ticks * 100 / 60;
+  UINT32 seconds = ticks / 60;
+  UINT32 minutes = seconds / 60;
+  UINT32 hours = seconds / 3600;
+  seconds = seconds % 60;
+  minutes = minutes % 60;
+  centiseconds = centiseconds % 100;
+  char timebuf[32];
+  snprintf(timebuf, sizeof(timebuf), "%02u:%02u:%02u.%02u", hours, minutes, seconds, centiseconds);
+
+  drawshadowsmallfontstring(blitbuf, timebuf, color, x, y);
+}
 
 void score_display(VIEWPORT *player)
 {
@@ -278,6 +482,13 @@ void score_display(VIEWPORT *player)
   frame = anim_forceframe (orgscore, cyfer);
   frame->draw(*player->loadedmap->blitbuf,70 + (12*40) + ((sinus512[xcnt]*10)>>10) + scoreshift, 414 + ((sinus512[ycnt]*10)>>10) );
 #endif
+
+  if (speedrun_state.running)
+  {
+    drawgametime(speedrun_state.gametime, *player->loadedmap->blitbuf, 0x10, 8, 8);
+
+    drawgametime(speedrun_state.leveltime[world*4+level], *player->loadedmap->blitbuf, 0x10, 8, 20);
+  }
 }
 
 


### PR DESCRIPTION
1. Add the menu option
2. Add a game and level timer in the top left during gameplay

These timers increment in ticks exactly from the first frame of a level, to the point that mc_autorun is set to something other than 0. To my knowledge, these points are when hitting the level end sign, and when killing a boss.

Additionally, "PLAY" is replaced with "CONTINUE", and another menu item "NEW GAME" is added. The latter resets the collected dark diamonds and highest level progression before entering puzzle select.