### PR TITLE
Change SR timer cutoff to play_madeit sound

### DIFF
--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -1862,6 +1862,7 @@ HEARTBEAT_FN MC_heartbeatstart(void)
     }
   video->palette(gamepal);
 
+  speedrun_state.level_complete = false;
   curlevel = world*4+level;
   speedrun_state.leveltime[curlevel] = 0;
 
@@ -2647,7 +2648,7 @@ if(hoi!=NULL)
 
 #endif
 
-  if (mc_autorun == 0)
+  if (!speedrun_state.level_complete)
   {
     speedrun_state.gametime += 1;
     speedrun_state.leveltime[world*4+level] += 1;

--- a/Classes/moonchild/mc.hpp
+++ b/Classes/moonchild/mc.hpp
@@ -65,6 +65,7 @@ struct SPEEDRUN_STATE
   UINT32 gametime;
   UINT32 leveltime[16];
   bool running;
+  bool level_complete;
 };
 extern SPEEDRUN_STATE speedrun_state;
 

--- a/Classes/moonchild/sound.cpp
+++ b/Classes/moonchild/sound.cpp
@@ -3,6 +3,7 @@
 #include <objects.hpp>
 #include <globals.hpp>
 #include <prefs.hpp>
+#include <mc.hpp>
 
 #define DEMOVERSION2
 
@@ -1067,10 +1068,11 @@ void stop_cammove(void)
 
 void play_madeit(void)
 {
-  if (audio->get_dsound() && sfxflg) // is dsound on?
+  if (audio->get_dsound() && sfxflg && !speedrun_state.level_complete) // is dsound on?
   {
     audio->play_sound_1shot(wav_madeit,0,0);
   }
+  speedrun_state.level_complete = true;
 }
 
 void play_heks(INT32 x, INT32 y)


### PR DESCRIPTION
Noticed during 3-4 that the timer is not pausing when defeating the boss. mc_autorun is not always set when playing the `madeit` sound.

Instead, let's just cut the time at `play_madeit`, since this is always used when indicating end-of-level, and can also be used for manual timing as well.

(I have more stuff coming, so this doesn't need an immediate release).