### PR TITLE
Hide and show mouse cursor on fullscreen toggle

### DIFF
--- a/Platform/Backends/Window/SDL3Window.cpp
+++ b/Platform/Backends/Window/SDL3Window.cpp
@@ -205,10 +205,12 @@ void SDL3Window::PumpOSEvents(IInput* sink, bool& outExitRequested)
         switch (sdlEvent.type)
         {
             case SDL_EVENT_WINDOW_ENTER_FULLSCREEN:
+                SDL_HideCursor();
                 DisplayBridge::NotifyFullscreenChange(1);
                 break;
 
             case SDL_EVENT_WINDOW_LEAVE_FULLSCREEN:
+                SDL_ShowCursor();
                 DisplayBridge::NotifyFullscreenChange(0);
                 break;
 


### PR DESCRIPTION
There was a request in the discord to hide the mouse cursor in fullscreen; this makes the minimum changes necessary for that. Practically speaking, it should never happen that you need to see the mouse cursor when the game is in fullscreen, and the window can be maximized for now if there is some scenario where that is the case.