### PR TITLE
Use const char* arguments to fix GCC -Wwrite-strings warnings.

### DIFF
--- a/Classes/framewrk/blitbuf.cpp
+++ b/Classes/framewrk/blitbuf.cpp
@@ -75,7 +75,7 @@ Cblitbuf::Cblitbuf(Cvideo *video)
 //  log_out("Construction succesful!");
 }
 
-Cblitbuf::Cblitbuf(char *pcx_filename, UINT16 top_margin, UINT16 bottom_margin, UINT16 forcesystemmem)
+Cblitbuf::Cblitbuf(const char *pcx_filename, UINT16 top_margin, UINT16 bottom_margin, UINT16 forcesystemmem)
 {
   VG_BOOLEAN rc;
   UINT16 w;
@@ -217,7 +217,7 @@ void Cblitbuf::load_mem(UINT16 x, UINT16 y, UINT16 w, UINT16 h, BYTE *buf)
 {
 }
 
-VG_BOOLEAN Cblitbuf::save_pcx(char *filename, BYTE *palette)
+VG_BOOLEAN Cblitbuf::save_pcx(const char *filename, BYTE *palette)
 {
   BYTE vga_pal[256*3];
   VG_BOOLEAN rc;

--- a/Classes/framewrk/fastfile.cpp
+++ b/Classes/framewrk/fastfile.cpp
@@ -122,7 +122,7 @@ int stricmp( char* s1, char* s2 )
  * Initialize for fast file access. The master file and maximum number
  * of open "files" are specified.
  */
-int FastFileInit( char *fname, int max_handles )
+int FastFileInit( const char *fname, int max_handles )
 {
 //    HRSRC  h;
 
@@ -225,13 +225,13 @@ void FastFileFini( void )
  *
  * Search the directory for the file, and return a file handle if found.
  */
-HFASTFILE FastFileOpen( char * name )
+HFASTFILE FastFileOpen( const char * name )
 {
 
     FILEENTRY   fe;
     LPFILEENTRY pfe;
 #if USEBASENAME
-    char *baseptr;
+    const char *baseptr;
 #endif // USEBASENAME
 
     

--- a/Classes/framewrk/fastfile.h
+++ b/Classes/framewrk/fastfile.h
@@ -21,9 +21,9 @@ typedef struct {
     LPFILEENTRY pfe;
 } FILEHANDLE, *LPFILEHANDLE;
 
-extern int FastFileInit( char *fname, int max_handles );
+extern int FastFileInit( const char *fname, int max_handles );
 extern void FastFileFini( void );
-extern HFASTFILE FastFileOpen( char *name );
+extern HFASTFILE FastFileOpen( const char *name );
 extern bool FastFileClose( HFASTFILE pfe );
 extern bool FastFileRead( HFASTFILE pfh, void *ptr, int size );
 extern bool FastFileSeek( HFASTFILE pfe, int off, int how );

--- a/Classes/framewrk/movie.hpp
+++ b/Classes/framewrk/movie.hpp
@@ -27,7 +27,7 @@ public:
   Cmovie    (Caudio *audio);
   ~Cmovie   (void);
 
-  Smack    *open(char *filename);
+  Smack    *open(const char *filename);
   void      close(Smack *smk);
 
   void      playtovideo(Smack *smk, Cvideo *video, Cblitbuf *hulpbuf, UINT16 zoomfactor);

--- a/Classes/framewrk/pcx.hpp
+++ b/Classes/framewrk/pcx.hpp
@@ -1,11 +1,11 @@
 #ifndef _PCX_HPP
 #define _PCX_HPP
 
-VG_BOOLEAN PCX_stat(char *fname, UINT16 *width, UINT16 *height);
-VG_BOOLEAN PCX_load(char *fname, BYTE *buffer, BYTE *palette);
-VG_BOOLEAN PCX_ff_save(char *fname, BYTE *buffer, UINT16 width, UINT16 height, BYTE *palette);
+VG_BOOLEAN PCX_stat(const char *fname, UINT16 *width, UINT16 *height);
+VG_BOOLEAN PCX_load(const char *fname, BYTE *buffer, BYTE *palette);
+VG_BOOLEAN PCX_ff_save(const char *fname, BYTE *buffer, UINT16 width, UINT16 height, BYTE *palette);
 void       PCX_pal8to6(BYTE *palette, int count);
 void       PCX_pal6to8(BYTE *palette, int count);
-void       PCX_dump(char *filename, FILE *out);
+void       PCX_dump(const char *filename, FILE *out);
 
 #endif /* _PCX_HPP */

--- a/Classes/framewrk/pcxff.cpp
+++ b/Classes/framewrk/pcxff.cpp
@@ -10,13 +10,13 @@
 #include "frm_int.hpp"
 
 
-VG_BOOLEAN PCX_ff_save(char *fname, BYTE *buffer, UINT16 width, UINT16 height, BYTE *palette)
+VG_BOOLEAN PCX_ff_save(const char *fname, BYTE *buffer, UINT16 width, UINT16 height, BYTE *palette)
 {
 	return VG_TRUE;
 }
 
 
-VG_BOOLEAN PCX_ff_stat(char *fname, UINT16 *width, UINT16 *height)
+VG_BOOLEAN PCX_ff_stat(const char *fname, UINT16 *width, UINT16 *height)
 {
   HFASTFILE fp;
   bool rc;
@@ -52,7 +52,7 @@ VG_BOOLEAN PCX_ff_stat(char *fname, UINT16 *width, UINT16 *height)
 // gebuffered load versie!
 #define BUFFERSIZE (128)
 
-VG_BOOLEAN PCX_ff_load(char *fname, BYTE *buffer, BYTE *palette)
+VG_BOOLEAN PCX_ff_load(const char *fname, BYTE *buffer, BYTE *palette)
 {
 	unsigned char TempBuffer[BUFFERSIZE];
 	HFASTFILE  fp;
@@ -164,7 +164,7 @@ VG_BOOLEAN PCX_ff_load(char *fname, BYTE *buffer, BYTE *palette)
 }
 
 
-void PCX_ff_dump(char *filename, FILE *out)
+void PCX_ff_dump(const char *filename, FILE *out)
 {
   UINT16 width, height;
   BYTE pal[256*3];

--- a/Classes/framewrk/pcxff.hpp
+++ b/Classes/framewrk/pcxff.hpp
@@ -1,8 +1,8 @@
 #ifndef _PCXFF_HPP
 #define _PCXFF_HPP
 
-VG_BOOLEAN PCX_ff_stat(char *fname, UINT16 *width, UINT16 *height);
-VG_BOOLEAN PCX_ff_load(char *fname, BYTE *buffer, BYTE *palette);
-void       PCX_ff_dump(char *filename, FILE *out);
+VG_BOOLEAN PCX_ff_stat(const char *fname, UINT16 *width, UINT16 *height);
+VG_BOOLEAN PCX_ff_load(const char *fname, BYTE *buffer, BYTE *palette);
+void       PCX_ff_dump(const char *filename, FILE *out);
 
 #endif /* _PCXFF_HPP */

--- a/Classes/framewrk/video.hpp
+++ b/Classes/framewrk/video.hpp
@@ -101,11 +101,11 @@ public:
   Cblitbuf(Cvideo *video);      // give a blitbuffer description of the videobackbuffer
   Cblitbuf(UINT16 width, UINT16 height, UINT16 top_margin, UINT16 bottom_margin);
   Cblitbuf(UINT16 width, UINT16 height, UINT16 top_margin, UINT16 bottom_margin, UINT16 forcesystemmem);
-  Cblitbuf(char *pcx_filename, UINT16 top_margin, UINT16 bottom_margin, UINT16 forcesystemmem = 0); // create with dimensions of PCX file
+  Cblitbuf(const char *pcx_filename, UINT16 top_margin, UINT16 bottom_margin, UINT16 forcesystemmem = 0); // create with dimensions of PCX file
   ~Cblitbuf(void);
   void save_mem(UINT16 x, UINT16 y, UINT16 w, UINT16 h, BYTE *buf);
   void load_mem(UINT16 x, UINT16 y, UINT16 w, UINT16 h, BYTE *buf);
-  VG_BOOLEAN save_pcx(char *filename, BYTE *palette);
+  VG_BOOLEAN save_pcx(const char *filename, BYTE *palette);
   void compiled_sprite(UINT16 x, UINT16 y, COMP_SPRITE compspr);
 
   void dump(FILE *fd);

--- a/Classes/moonchild/anim.cpp
+++ b/Classes/moonchild/anim.cpp
@@ -94,7 +94,7 @@ Cspr_frame *anim_setsequence(ANIM *anim, int seq, int force)
 }
 
 
-ANIM *anim_retrieveanim(char *animname)
+ANIM *anim_retrieveanim(const char *animname)
 {
   ANIM *myanim;
   vg_dll_first(allanims);

--- a/Classes/moonchild/anim.hpp
+++ b/Classes/moonchild/anim.hpp
@@ -4,7 +4,7 @@
 #include <frm_wrk.hpp>
 #include <mc.hpp>
 
-ANIM *anim_retrieveanim(char *animname);
+ANIM *anim_retrieveanim(const char *animname);
 ANIM *copy_anim(ANIM *oldanim);
 Cspr_frame *anim_forceframe(ANIM *anim, INT16 framenr);
 Cspr_frame *anim_nextframe(ANIM *anim);

--- a/Classes/moonchild/asset.cpp
+++ b/Classes/moonchild/asset.cpp
@@ -7,10 +7,10 @@
 
 
 static char *asset_nextstring(void);
-static char *asset_zoek(char *string);
+static char *asset_zoek(const char *string);
 static void  asset_rewind();
 static void  asset_close(void);
-static int   asset_open(char * name);
+static int   asset_open(const char * name);
 
 static int seqcontext_add(char *string);
 static int anmcontext_add(char *string);
@@ -35,7 +35,7 @@ Cspr_frame *seqframes[100];
 int seqframescnt;
 
 
-static int asset_open(char * name)
+static int asset_open(const char * name)
 {
   assetfp = fopen(name, "rb");
   if (!assetfp)
@@ -61,7 +61,7 @@ static void asset_rewind(void)
 }
 
 
-static char *asset_zoek(char *string)
+static char *asset_zoek(const char *string)
 {
   char *dumstring = NULL;
   short int cmpcnt;
@@ -99,7 +99,7 @@ static char *asset_nextstring(void)
 
 /*****************************************************************************/
 
-int asset_parse(char * assetname)
+int asset_parse(const char * assetname)
 {
   char *passstring;
   int inseq = 0;

--- a/Classes/moonchild/asset.hpp
+++ b/Classes/moonchild/asset.hpp
@@ -1,5 +1,5 @@
 /* ASSET PARSER INCLUDE FILE */
 
-int asset_parse(char * assetname);
+int asset_parse(const char * assetname);
 void asset_removeall(void);
 

--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -262,7 +262,7 @@ HEARTBEAT_FN MC_alldiams(void);
 
 void killpuzzle(void);
 UINT16 compscore(char *score1, char *score2);
-int  startmovie( char *movname, char *movkadername);
+int  startmovie( const char *movname, const char *movkadername);
 void handleinput1shot(void);
 void handleinputloop(void);
 UINT16 convscore(void);
@@ -785,8 +785,8 @@ UINT16 swirltab[64*4];  //upto 64 swirling letters simultaneously  (x,y,amp,char
 /*!	Converts the given filename to its fullpath using unicode
 *///-----------------------------------------------------------------------
 
-extern char *FullPath( char *a_File );
-extern char *FullWritablePath( char *a_File );
+extern const char *FullPath( const char *a_File );
+extern const char *FullWritablePath( const char *a_File );
 #ifdef __EMSCRIPTEN__
 extern void SyncPersistentStorage();
 #endif
@@ -1285,7 +1285,7 @@ void disablefastfile(void)
 }
 
 
-int startmovie( char *movname, char *movkadername)
+int startmovie( const char *movname, const char *movkadername)
 {
 
 // are the movies turned on???
@@ -6385,7 +6385,7 @@ int collision(UINT16 x, UINT16 y)
 
 // LOAD/SAVE ROUTINES
 
-VG_BOOLEAN loadfile(char * fname, char *buffer, UINT32 length)
+VG_BOOLEAN loadfile(const char * fname, char *buffer, UINT32 length)
 {
     FILE *fp;
     
@@ -6404,7 +6404,7 @@ VG_BOOLEAN loadfile(char * fname, char *buffer, UINT32 length)
 }
 
 
-VG_BOOLEAN savefile(char * fname, char *buffer, UINT32 length)
+VG_BOOLEAN savefile(const char * fname, char *buffer, UINT32 length)
 {
     FILE *fp;
     
@@ -6421,7 +6421,7 @@ VG_BOOLEAN savefile(char * fname, char *buffer, UINT32 length)
     return VG_TRUE;
 }
 
-VG_BOOLEAN loaddocfile(char * fname, char *buffer, UINT32 length)
+VG_BOOLEAN loaddocfile(const char * fname, char *buffer, UINT32 length)
 {
     FILE *fp;
     
@@ -6440,7 +6440,7 @@ VG_BOOLEAN loaddocfile(char * fname, char *buffer, UINT32 length)
 }
 
 
-VG_BOOLEAN savedocfile(char * fname, char *buffer, UINT32 length)
+VG_BOOLEAN savedocfile(const char * fname, char *buffer, UINT32 length)
 {
     FILE *fp;
     

--- a/Classes/moonchild/mc.hpp
+++ b/Classes/moonchild/mc.hpp
@@ -81,10 +81,10 @@ void bullet_add(OBJECT *bullet);
 void bullet_init(void);
 
 
-VG_BOOLEAN loadfile(char * fname, char *buffer, UINT32 length);
-VG_BOOLEAN savefile(char * fname, char *buffer, UINT32 length);
-VG_BOOLEAN loaddocfile(char * fname, char *buffer, UINT32 length);
-VG_BOOLEAN savedocfile(char * fname, char *buffer, UINT32 length);
+VG_BOOLEAN loadfile(const char * fname, char *buffer, UINT32 length);
+VG_BOOLEAN savefile(const char * fname, char *buffer, UINT32 length);
+VG_BOOLEAN loaddocfile(const char * fname, char *buffer, UINT32 length);
+VG_BOOLEAN savedocfile(const char * fname, char *buffer, UINT32 length);
 
 #endif
 

--- a/Platform/App/Resources.cpp
+++ b/Platform/App/Resources.cpp
@@ -114,14 +114,14 @@ static void EnsureBasePath()
 static char FullPathBuf[2048];
 static char WritablePathBuf[2048];
 
-char* FullPath(char* file)
+const char* FullPath(const char* file)
 {
     EnsureBasePath();
     std::snprintf(FullPathBuf, sizeof(FullPathBuf), "%s%s", DataPath, file);
     return FullPathBuf;
 }
 
-char* FullWritablePath(char* file)
+const char* FullWritablePath(const char* file)
 {
     EnsureBasePath();
     std::snprintf(WritablePathBuf, sizeof(WritablePathBuf), "%s%s", WritablePath, file);

--- a/Platform/App/Resources.h
+++ b/Platform/App/Resources.h
@@ -1,7 +1,7 @@
 #pragma once
 
-char* FullPath(char* file);
-char* FullWritablePath(char* file);
+const char* FullPath(const char* file);
+const char* FullWritablePath(const char* file);
 
 void LoadProgress();
 void SaveProgress();

--- a/Platform/Backends/Audio/SDL3Audio.cpp
+++ b/Platform/Backends/Audio/SDL3Audio.cpp
@@ -14,7 +14,7 @@
 #include <memory>
 #include <vector>
 
-extern char* FullPath(char* file);
+extern const char* FullPath(const char* file);
 
 static constexpr int MIX_FREQUENCY = 48000;
 static constexpr int MIX_CHANNELS  = 2;

--- a/Platform/Bridges/MovieBridge.cpp
+++ b/Platform/Bridges/MovieBridge.cpp
@@ -29,7 +29,7 @@ static const char* ResolveMoviePath(const char* mpgFileName)
     static char path[2048];
     char          rel[512];
     std::snprintf(rel, sizeof(rel), "movies/%s", mpgFileName);
-    char* resolved = FullPath(rel);
+    const char* resolved = FullPath(rel);
     std::snprintf(path, sizeof(path), "%s", resolved);
     return path;
 }
@@ -162,7 +162,7 @@ Cmovie::~Cmovie(void)
     TeardownStream();
 }
 
-Smack* Cmovie::open(char* filename)
+Smack* Cmovie::open(const char* filename)
 {
     TeardownStream();
 


### PR DESCRIPTION
This gets rid of a lot of warnings, but there are still many more...