### PR TITLE
Add menu letterswirl skip on shoot button

### DIFF
--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -7049,6 +7049,13 @@ HEARTBEAT_FN MC_options(void)
 
   handleinput1shot();
 
+  if (shootkey == 1)
+    {
+      menupoint = menu1;
+      menuitem = 0;
+      return (HEARTBEAT_FN) MC_buildmenu;
+    }
+
   letterswirlscan();
   letterswirlin();
 


### PR DESCRIPTION
The speedrunners want this to save a little bit of time on resets. I think it's a reasonable change, even if it diverges from the original game.