### PR TITLE
Fix PRNG seed to be actually random

### DIFF
--- a/Classes/moonchild/mc.cpp
+++ b/Classes/moonchild/mc.cpp
@@ -5510,7 +5510,8 @@ void glob_init(void)
     {
       sinus512[i] = (short) (sin(((PI*2)/1024)*i) * 512);
     }
-  PCG32Seed(0);   //time()
+  time_t timedata = time(NULL);
+  PCG32Seed((unsigned int)timedata);
 
   log_out("allocing memory for dots");
   dotbase = (UINTPTR *) malloc(sizeof(UINTPTR) * 10000); //10000 pixels


### PR DESCRIPTION
The PRNG was seeded to 0 which could be abused to make the 3-4 doolhof layout consistent.